### PR TITLE
Add LangChain-based circuit schematic chat interface

### DIFF
--- a/scr/README.md
+++ b/scr/README.md
@@ -1,73 +1,49 @@
-# React + TypeScript + Vite
+# Schematicia Studio
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Interfaz web construida con Vite y React que combina LangChain con los modelos de OpenAI para generar propuestas de circuitos electrónicos a partir de instrucciones en lenguaje natural.
 
-Currently, two official plugins are available:
+El asistente produce:
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Respuestas conversacionales que explican el diseño.
+- Una estructura JSON con componentes, conexiones, notas y advertencias.
+- Una visualización SVG sencilla del esquema para comprender las relaciones principales.
 
-## React Compiler
+## Requisitos
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- Node.js 20 o superior.
+- Una API key válida de OpenAI con acceso al modelo que quieras utilizar.
 
-## Expanding the ESLint configuration
+## Puesta en marcha
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+```bash
+# Instala dependencias
+npm install
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+# Ejecuta el entorno de desarrollo en http://localhost:5173
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Cuando abras la aplicación:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+1. Despliega la sección **Configuración** en la parte superior derecha.
+2. Introduce tu API key de OpenAI. El valor se almacena únicamente en tu navegador mediante `localStorage`.
+3. Selecciona un modelo (por defecto `gpt-4o-mini`) o especifica uno personalizado.
+4. Ajusta la temperatura si necesitas respuestas más creativas.
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+Después, describe el circuito que deseas prototipar. El asistente sugerirá componentes y conexiones, y generará una visualización básica basada en el JSON devuelto por LangChain.
+
+## Personalización
+
+- El esquema JSON se valida en el navegador y se muestra en la sección derecha. Puedes copiarlo para integrarlo en otros flujos de trabajo.
+- El lienzo SVG interpreta posiciones sugeridas por el modelo (`position.x`, `position.y`). Si no se proporcionan, se calcula una cuadrícula automática.
+- El prompt del asistente se define en `src/lib/circuitDesigner.ts`; puedes adaptarlo para ajustarlo a tus normas de diseño.
+
+## Scripts disponibles
+
+- `npm run dev`: inicia Vite en modo desarrollo.
+- `npm run build`: genera la versión de producción y valida los tipos.
+- `npm run lint`: ejecuta ESLint sobre el proyecto.
+
+## Seguridad
+
+El proyecto no incluye backend. Las peticiones a OpenAI se realizan desde el navegador del usuario. Evita desplegar esta aplicación tal cual en producción sin incorporar un proxy seguro que proteja tu API key.

--- a/scr/src/App.css
+++ b/scr/src/App.css
@@ -1,42 +1,462 @@
-#root {
-  max-width: 1280px;
+.app {
+  max-width: 1260px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 2.5rem clamp(1.5rem, 2vw, 3rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  min-height: 100vh;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.app__header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  color: #f8fafc;
+}
+
+.app__subtitle {
+  margin: 0.5rem 0 0;
+  max-width: 48rem;
+  line-height: 1.6;
+  color: #cbd5f5;
+}
+
+.app__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  flex: 1;
+}
+
+.panel {
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.1), rgba(15, 23, 42, 0.6) 55%);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.4);
+}
+
+.panel--chat {
+  min-height: 520px;
+}
+
+.panel__body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.panel__body--scroll {
+  padding: 1.5rem 1.75rem 2rem;
+  overflow-y: auto;
+}
+
+.panel__footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.5) 100%);
+}
+
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message {
+  max-width: 90%;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.message--assistant {
+  align-self: flex-start;
+  background: rgba(59, 130, 246, 0.15);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.message--user {
+  align-self: flex-end;
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.message__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.message__content {
+  margin: 0;
+  white-space: pre-wrap;
+  color: #e2e8f0;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
+.message--loading .message__content {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.loader-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.7);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.loader-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.loader-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.85);
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.composer__input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  font: inherit;
+  resize: vertical;
+  min-height: 120px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.composer__input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+
+.composer__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.button {
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.35);
+  opacity: 0.7;
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.35);
+}
+
+.button:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.notice {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(30, 64, 175, 0.25);
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  color: #bfdbfe;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.notice--error {
+  background: rgba(220, 38, 38, 0.2);
+  border-color: rgba(220, 38, 38, 0.45);
+  color: #fecaca;
+}
+
+.settings {
+  min-width: 260px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.45);
+  padding: 0.8rem 1rem;
+  color: #e2e8f0;
+}
+
+.settings summary {
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.settings[open] summary {
+  margin-bottom: 0.75rem;
+}
+
+.settings__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.field__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.field__input {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.55rem 0.75rem;
+  color: #f1f5f9;
+  font: inherit;
+}
+
+.field__input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+
+.field__help {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.schematic-placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+
+.schematic-placeholder ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #94a3b8;
+}
+
+.schematic-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.schematic-details__intro h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #f8fafc;
+}
+
+.schematic-details__intro p {
+  margin: 0.5rem 0 0;
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+
+.schematic-canvas {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 18px;
+  padding: 1rem;
+  overflow: hidden;
+}
+
+.schematic-canvas svg {
+  width: 100%;
+  height: auto;
+}
+
+.schematic-node rect {
+  fill: rgba(59, 130, 246, 0.25);
+  stroke: rgba(96, 165, 250, 0.6);
+  stroke-width: 1.5;
+}
+
+.schematic-node__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-anchor: middle;
+  fill: #f8fafc;
+}
+
+.schematic-node__type {
+  font-size: 0.78rem;
+  text-anchor: middle;
+  fill: #bfdbfe;
+}
+
+.schematic-connection__line {
+  stroke: rgba(148, 163, 184, 0.65);
+  stroke-width: 2.2;
+}
+
+.schematic-connection__label {
+  font-size: 0.72rem;
+  fill: #fde68a;
+  text-anchor: middle;
+}
+
+.schematic-connection__description {
+  font-size: 0.68rem;
+  fill: #f1f5f9;
+  text-anchor: middle;
+}
+
+.schematic-details__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.schematic-details__section h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+}
+
+.schematic-details__section--warning {
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(185, 28, 28, 0.28);
+  color: #fee2e2;
+}
+
+.schematic-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.schematic-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: #e2e8f0;
+}
+
+.schematic-list__type {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a5b4fc;
+}
+
+.schematic-list__description {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.55;
+}
+
+.schematic-details__json {
+  margin: 0;
+  padding: 1rem;
+  background: rgba(2, 6, 23, 0.6);
+  border-radius: 12px;
+  overflow: auto;
+  font-size: 0.8rem;
+  color: #cbd5f5;
+}
+
+@media (max-width: 1080px) {
+  .app__content {
+    grid-template-columns: 1fr;
+  }
+
+  .panel--chat {
+    order: 2;
   }
 }
 
-.card {
-  padding: 2em;
-}
+@media (max-width: 720px) {
+  .app {
+    padding: 2rem 1rem 2.5rem;
+  }
 
-.read-the-docs {
-  color: #888;
+  .settings {
+    width: 100%;
+  }
+
+  .panel__body {
+    padding: 1.25rem;
+  }
+
+  .panel__footer {
+    padding: 1rem 1.25rem 1.25rem;
+  }
 }

--- a/scr/src/App.tsx
+++ b/scr/src/App.tsx
@@ -1,34 +1,149 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useMemo, useState } from 'react'
+
+import { MessageComposer } from './components/MessageComposer'
+import { MessageList } from './components/MessageList'
+import { SettingsPanel } from './components/SettingsPanel'
+import { SchematicDetails } from './components/SchematicDetails'
+import { useLocalStorage } from './hooks/useLocalStorage'
+import { generateCircuitDesign } from './lib/circuitDesigner'
+import type { ChatMessage } from './types/chat'
+import type { CircuitPlan } from './types/circuit'
 import './App.css'
 
+const INITIAL_ASSISTANT_MESSAGE = `Hola, soy Schematicia. Describe el circuito que necesitas y te ayudaré a proponer un esquema,
+lista de componentes y recomendaciones para construirlo de forma segura.`
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: 'welcome',
+      role: 'assistant',
+      content: INITIAL_ASSISTANT_MESSAGE,
+      createdAt: Date.now(),
+    },
+  ])
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [currentPlan, setCurrentPlan] = useState<CircuitPlan | null>(null)
+
+  const [apiKey, setApiKey] = useLocalStorage('schematicia_openai_api_key', '')
+  const [model, setModel] = useLocalStorage('schematicia_openai_model', 'gpt-4o-mini')
+  const [temperature, setTemperature] = useLocalStorage('schematicia_openai_temperature', 0.2)
+
+  const canSendMessages = useMemo(() => Boolean(apiKey) && Boolean(model), [apiKey, model])
+
+  const handleSendMessage = async (rawMessage: string) => {
+    const text = rawMessage.trim()
+    if (!text) {
+      return
+    }
+
+    const history = [...messages]
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: text,
+      createdAt: Date.now(),
+    }
+
+    setMessages([...history, userMessage])
+    setIsLoading(true)
+    setErrorMessage(null)
+
+    try {
+      if (!apiKey) {
+        throw new Error('Agrega tu API key de OpenAI en la sección de configuración.')
+      }
+
+      if (!model) {
+        throw new Error('Selecciona o escribe un modelo válido de OpenAI.')
+      }
+
+      const design = await generateCircuitDesign({
+        apiKey,
+        model,
+        temperature: typeof temperature === 'number' ? temperature : Number(temperature) || 0.2,
+        userInput: text,
+        history,
+      })
+
+      const assistantMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: design.response,
+        createdAt: Date.now(),
+      }
+
+      setMessages([...history, userMessage, assistantMessage])
+      setCurrentPlan(design.circuit)
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'No fue posible generar el diseño. Intenta nuevamente en unos instantes.'
+
+      setErrorMessage(message)
+
+      const assistantMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: `⚠️ ${message}`,
+        createdAt: Date.now(),
+      }
+
+      setMessages([...history, userMessage, assistantMessage])
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <header className="app__header">
+        <div>
+          <h1>Schematicia Studio</h1>
+          <p className="app__subtitle">
+            Diseña esquemas electrónicos con ayuda de un modelo de lenguaje y obtén visualizaciones rápidas para tus prototipos.
+          </p>
+        </div>
+        <SettingsPanel
+          apiKey={apiKey}
+          model={model}
+          temperature={typeof temperature === 'number' ? temperature : Number(temperature) || 0.2}
+          onApiKeyChange={setApiKey}
+          onModelChange={setModel}
+          onTemperatureChange={setTemperature}
+        />
+      </header>
+
+      <main className="app__content">
+        <section className="panel panel--chat">
+          <div className="panel__body">
+            <MessageList messages={messages} isLoading={isLoading} />
+          </div>
+          <div className="panel__footer">
+            {!canSendMessages ? (
+              <div className="notice">
+                <strong>Configura tu API key</strong>
+                <p>Agrega una API key válida de OpenAI para conversar con el asistente.</p>
+              </div>
+            ) : null}
+            {errorMessage ? <div className="notice notice--error">{errorMessage}</div> : null}
+            <MessageComposer
+              disabled={isLoading || !canSendMessages}
+              onSend={handleSendMessage}
+              placeholder="Ejemplo: Diseña un regulador de 5V con entrada de 12V para alimentar un microcontrolador."
+            />
+          </div>
+        </section>
+
+        <section className="panel panel--schematic">
+          <div className="panel__body panel__body--scroll">
+            <SchematicDetails plan={currentPlan} />
+          </div>
+        </section>
+      </main>
+    </div>
   )
 }
 

--- a/scr/src/components/MessageComposer.tsx
+++ b/scr/src/components/MessageComposer.tsx
@@ -1,0 +1,39 @@
+import { type FormEvent, useState } from 'react'
+
+interface MessageComposerProps {
+  disabled?: boolean
+  placeholder?: string
+  onSend: (message: string) => void
+}
+
+export function MessageComposer({ disabled, placeholder, onSend }: MessageComposerProps) {
+  const [value, setValue] = useState('')
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!value.trim()) {
+      return
+    }
+
+    onSend(value.trim())
+    setValue('')
+  }
+
+  return (
+    <form className="composer" onSubmit={handleSubmit}>
+      <textarea
+        className="composer__input"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder={placeholder ?? 'Describe el circuito que necesitas...'}
+        rows={4}
+        disabled={disabled}
+      />
+      <div className="composer__actions">
+        <button type="submit" className="button" disabled={disabled || value.trim().length === 0}>
+          Generar esquema
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/scr/src/components/MessageList.tsx
+++ b/scr/src/components/MessageList.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+
+import type { ChatMessage } from '../types/chat'
+
+interface MessageListProps {
+  messages: ChatMessage[]
+  isLoading: boolean
+}
+
+export function MessageList({ messages, isLoading }: MessageListProps) {
+  const endRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, isLoading])
+
+  return (
+    <div className="message-list">
+      {messages.map((message) => {
+        const author = message.role === 'user' ? 'Tú' : message.role === 'assistant' ? 'Schematicia' : 'Sistema'
+
+        return (
+          <article key={message.id} className={`message message--${message.role}`}>
+            <header className="message__meta">
+              <span className="message__author">{author}</span>
+            </header>
+            <p className="message__content">{message.content}</p>
+          </article>
+        )
+      })}
+
+      {isLoading ? (
+        <article className="message message--assistant message--loading">
+          <header className="message__meta">
+            <span className="message__author">Schematicia</span>
+          </header>
+          <div className="message__content">
+            <span className="loader-dot" />
+            <span className="loader-dot" />
+            <span className="loader-dot" />
+          </div>
+        </article>
+      ) : null}
+
+      <div ref={endRef} />
+    </div>
+  )
+}

--- a/scr/src/components/SchematicCanvas.tsx
+++ b/scr/src/components/SchematicCanvas.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react'
+
+import type { CircuitPlan } from '../types/circuit'
+
+const NODE_WIDTH = 160
+const NODE_HEIGHT = 64
+const HORIZONTAL_PADDING = 120
+const VERTICAL_SPACING = 120
+
+interface SchematicCanvasProps {
+  plan: CircuitPlan
+}
+
+export function SchematicCanvas({ plan }: SchematicCanvasProps) {
+  const layout = useMemo(() => {
+    const positions = new Map<string, { x: number; y: number }>()
+
+    plan.components.forEach((component, index) => {
+      if (component.position) {
+        positions.set(component.id, component.position)
+        return
+      }
+
+      const column = index % 2
+      const row = Math.floor(index / 2)
+      const x = HORIZONTAL_PADDING + column * (NODE_WIDTH + 120)
+      const y = 120 + row * VERTICAL_SPACING
+      positions.set(component.id, { x, y })
+    })
+
+    const width = plan.components.length > 1 ? HORIZONTAL_PADDING * 2 + NODE_WIDTH * 2 + 120 : 520
+    const height = Math.max(440, 200 + Math.ceil(plan.components.length / 2) * VERTICAL_SPACING)
+
+    return { positions, width, height }
+  }, [plan.components])
+
+  return (
+    <div className="schematic-canvas">
+      <svg viewBox={`0 0 ${layout.width} ${layout.height}`} role="img" aria-label="Esquema del circuito propuesto">
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+
+        {plan.connections.map((connection, index) => {
+          const from = layout.positions.get(connection.from)
+          const to = layout.positions.get(connection.to)
+          if (!from || !to) {
+            return null
+          }
+
+          const midX = (from.x + to.x) / 2
+          const midY = (from.y + to.y) / 2
+          const lineId = connection.id ?? `${connection.from}-${connection.to}-${index}`
+
+          return (
+            <g key={lineId} className="schematic-connection">
+              <line
+                x1={from.x}
+                y1={from.y}
+                x2={to.x}
+                y2={to.y}
+                markerEnd="url(#arrow)"
+                className="schematic-connection__line"
+              />
+              {connection.label ? (
+                <text x={midX} y={midY - 6} className="schematic-connection__label">
+                  {connection.label}
+                </text>
+              ) : null}
+              {connection.description ? (
+                <text x={midX} y={midY + 12} className="schematic-connection__description">
+                  {connection.description}
+                </text>
+              ) : null}
+            </g>
+          )
+        })}
+
+        {plan.components.map((component) => {
+          const position = layout.positions.get(component.id)
+          if (!position) {
+            return null
+          }
+
+          return (
+            <g key={component.id} className="schematic-node" transform={`translate(${position.x - NODE_WIDTH / 2}, ${position.y - NODE_HEIGHT / 2})`}>
+              <rect rx={12} ry={12} width={NODE_WIDTH} height={NODE_HEIGHT} />
+              <text x={NODE_WIDTH / 2} y={26} className="schematic-node__label">
+                {component.label}
+              </text>
+              <text x={NODE_WIDTH / 2} y={48} className="schematic-node__type">
+                {component.type}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/scr/src/components/SchematicDetails.tsx
+++ b/scr/src/components/SchematicDetails.tsx
@@ -1,0 +1,108 @@
+import type { CircuitPlan } from '../types/circuit'
+import { SchematicCanvas } from './SchematicCanvas'
+
+interface SchematicDetailsProps {
+  plan: CircuitPlan | null
+}
+
+export function SchematicDetails({ plan }: SchematicDetailsProps) {
+  if (!plan) {
+    return (
+      <div className="schematic-placeholder">
+        <h2>Visualización del esquema</h2>
+        <p>
+          Describe el circuito que quieres construir. El asistente generará una propuesta con componentes, conexiones y notas para
+          ayudarte a prototipar.
+        </p>
+        <ul>
+          <li>Indica el objetivo (por ejemplo: fuente regulada, sensor con microcontrolador, etapa de potencia, etc.).</li>
+          <li>Comparte restricciones importantes: voltaje de entrada, disponibilidad de componentes, o espacio físico.</li>
+          <li>Solicita optimizaciones como consumo, costo o facilidad de montaje.</li>
+        </ul>
+      </div>
+    )
+  }
+
+  return (
+    <div className="schematic-details">
+      <div className="schematic-details__intro">
+        <h2>{plan.title}</h2>
+        <p>{plan.summary}</p>
+      </div>
+
+      <SchematicCanvas plan={plan} />
+
+      <section className="schematic-details__section">
+        <h3>Componentes</h3>
+        <ul className="schematic-list">
+          {plan.components.map((component) => (
+            <li key={component.id} className="schematic-list__item">
+              <div>
+                <strong>{component.label}</strong>
+                <span className="schematic-list__type">{component.type}</span>
+              </div>
+              {component.description ? <p className="schematic-list__description">{component.description}</p> : null}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {plan.connections.length > 0 ? (
+        <section className="schematic-details__section">
+          <h3>Conexiones</h3>
+          <ul className="schematic-list">
+            {plan.connections.map((connection, index) => (
+              <li key={connection.id ?? `${connection.from}-${connection.to}-${index}`} className="schematic-list__item">
+                <div>
+                  <strong>{connection.from}</strong> → <strong>{connection.to}</strong>
+                </div>
+                {connection.label ? <span className="schematic-list__type">{connection.label}</span> : null}
+                {connection.description ? (
+                  <p className="schematic-list__description">{connection.description}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.notes.length > 0 ? (
+        <section className="schematic-details__section">
+          <h3>Notas de implementación</h3>
+          <ul>
+            {plan.notes.map((note, index) => (
+              <li key={index}>{note}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.assumptions.length > 0 ? (
+        <section className="schematic-details__section">
+          <h3>Suposiciones</h3>
+          <ul>
+            {plan.assumptions.map((assumption, index) => (
+              <li key={index}>{assumption}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {plan.warnings.length > 0 ? (
+        <section className="schematic-details__section schematic-details__section--warning">
+          <h3>Advertencias</h3>
+          <ul>
+            {plan.warnings.map((warning, index) => (
+              <li key={index}>{warning}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="schematic-details__section">
+        <h3>JSON sugerido</h3>
+        <pre className="schematic-details__json">{JSON.stringify(plan, null, 2)}</pre>
+      </section>
+    </div>
+  )
+}

--- a/scr/src/components/SettingsPanel.tsx
+++ b/scr/src/components/SettingsPanel.tsx
@@ -1,0 +1,95 @@
+interface SettingsPanelProps {
+  apiKey: string
+  model: string
+  temperature: number
+  onApiKeyChange: (value: string) => void
+  onModelChange: (value: string) => void
+  onTemperatureChange: (value: number) => void
+}
+
+const COMMON_MODELS = [
+  { value: 'gpt-4o-mini', label: 'GPT-4o mini (recomendado)' },
+  { value: 'gpt-4.1-mini', label: 'GPT-4.1 mini' },
+  { value: 'o4-mini', label: 'o4-mini' },
+]
+
+export function SettingsPanel({
+  apiKey,
+  model,
+  temperature,
+  onApiKeyChange,
+  onModelChange,
+  onTemperatureChange,
+}: SettingsPanelProps) {
+  const isCustomModel = !COMMON_MODELS.some((option) => option.value === model) || model === ''
+  const selectValue = isCustomModel ? 'custom' : model
+
+  return (
+    <details className="settings">
+      <summary>Configuración</summary>
+      <div className="settings__content">
+        <label className="field">
+          <span className="field__label">OpenAI API key</span>
+          <input
+            type="password"
+            className="field__input"
+            value={apiKey}
+            onChange={(event) => onApiKeyChange(event.target.value)}
+            placeholder="sk-..."
+            autoComplete="off"
+          />
+        </label>
+
+        <label className="field">
+          <span className="field__label">Modelo</span>
+          <select
+            className="field__input"
+            value={selectValue}
+            onChange={(event) => {
+              if (event.target.value === 'custom') {
+                onModelChange('')
+                return
+              }
+
+              onModelChange(event.target.value)
+            }}
+          >
+            {COMMON_MODELS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+            <option value="custom">Personalizado</option>
+          </select>
+          {isCustomModel ? (
+            <input
+              className="field__input"
+              type="text"
+              placeholder="Nombre del modelo"
+              value={model}
+              onChange={(event) => onModelChange(event.target.value)}
+            />
+          ) : null}
+        </label>
+
+        <label className="field">
+          <span className="field__label">Creatividad (temperatura)</span>
+          <input
+            className="field__input"
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            value={temperature}
+            onChange={(event) => onTemperatureChange(Number(event.target.value))}
+          />
+          <span className="field__help">Valor actual: {temperature.toFixed(1)}</span>
+        </label>
+
+        <p className="settings__hint">
+          La clave se guarda únicamente en tu navegador mediante <code>localStorage</code>. No se envía a ningún servidor.
+        </p>
+      </div>
+    </details>
+  )
+}

--- a/scr/src/hooks/useLocalStorage.ts
+++ b/scr/src/hooks/useLocalStorage.ts
@@ -1,0 +1,40 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react'
+
+function readValue<T>(key: string, initialValue: T): T {
+  if (typeof window === 'undefined') {
+    return initialValue
+  }
+
+  try {
+    const item = window.localStorage.getItem(key)
+    if (item === null) {
+      return initialValue
+    }
+
+    return JSON.parse(item) as T
+  } catch (error) {
+    console.warn(`No fue posible leer la clave "${key}" de localStorage`, error)
+    return initialValue
+  }
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): readonly [T, Dispatch<SetStateAction<T>>] {
+  const [storedValue, setStoredValue] = useState<T>(() => readValue(key, initialValue))
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      window.localStorage.setItem(key, JSON.stringify(storedValue))
+    } catch (error) {
+      console.warn(`No fue posible escribir la clave "${key}" en localStorage`, error)
+    }
+  }, [key, storedValue])
+
+  return [storedValue, setStoredValue]
+}

--- a/scr/src/index.css
+++ b/scr/src/index.css
@@ -1,68 +1,31 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  line-height: 1.6;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color: #e2e8f0;
+  background-color: #020617;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(147, 51, 234, 0.1), transparent 50%),
+    linear-gradient(180deg, rgba(2, 6, 23, 1) 0%, rgba(15, 23, 42, 1) 100%);
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+a {
+  color: inherit;
 }

--- a/scr/src/lib/chat.ts
+++ b/scr/src/lib/chat.ts
@@ -1,0 +1,14 @@
+import type { ChatMessage } from '../types/chat'
+
+export function formatHistory(messages: ChatMessage[]): string {
+  if (messages.length === 0) {
+    return 'No hay conversación previa.'
+  }
+
+  return messages
+    .map((message) => {
+      const speaker = message.role === 'user' ? 'Usuario' : message.role === 'assistant' ? 'Asistente' : 'Sistema'
+      return `${speaker}: ${message.content}`
+    })
+    .join('\n')
+}

--- a/scr/src/lib/circuitDesigner.ts
+++ b/scr/src/lib/circuitDesigner.ts
@@ -1,0 +1,209 @@
+import type { ChatMessage } from '../types/chat'
+import type { CircuitDesignResponse, CircuitPlan } from '../types/circuit'
+import { formatHistory } from './chat'
+import { ChatOpenAI, ChatPromptTemplate, StructuredOutputParser } from './langchain'
+
+const parser = StructuredOutputParser.fromSpec<CircuitDesignResponse>({
+  instructions:
+    'Devuelve un objeto JSON con la forma { "response": string, "circuit": { "title": string, "summary": string, "components": Array<Component>, "connections": Array<Connection>, "notes": string[], "assumptions": string[], "warnings": string[] } }. Cada Component debe tener id, label, type y opcionalmente description, pins, position (con x e y numéricos). Cada Connection requiere from y to que coincidan con ids de componentes y puede incluir label, description e id.',
+  validate: validateCircuitDesign,
+})
+
+const prompt = ChatPromptTemplate.fromMessages([
+  [
+    'system',
+    `Eres Schematicia, una ingeniera electrónica experta. Tu tarea es interpretar instrucciones del usuario para diseñar circuitos
+electrónicos claros y didácticos. Siempre devuelves información estructurada en formato JSON siguiendo estrictamente las instrucciones de formato proporcionadas.
+
+- Prioriza la claridad pedagógica, explica cómo funciona el circuito.
+- Antes de generar una respuesta, valida que todas las referencias cruzadas (componentes y conexiones) coinciden.
+- Propón valores realistas, orientados a prototipos en protoboard o PCBs sencillas.
+- Cuando no puedas atender la solicitud, informa el motivo y sugiere alternativas seguras.
+
+Incluye recomendaciones de pruebas y advertencias si el diseño involucra altos voltajes o corrientes elevadas.
+{format_instructions}`,
+  ],
+  [
+    'user',
+    `Contexto previo:
+{history}
+
+Nueva petición:
+{input}`,
+  ],
+])
+
+interface GenerateCircuitOptions {
+  apiKey: string
+  model: string
+  temperature: number
+  userInput: string
+  history: ChatMessage[]
+}
+
+export async function generateCircuitDesign(options: GenerateCircuitOptions): Promise<CircuitDesignResponse> {
+  const { apiKey, model, temperature, userInput, history } = options
+
+  if (!apiKey) {
+    throw new Error('Debes proporcionar una API key de OpenAI para generar diseños.')
+  }
+
+  const llm = new ChatOpenAI({
+    apiKey,
+    model,
+    temperature,
+    maxRetries: 2,
+  })
+
+  const historyText = formatHistory(history)
+
+  const messages = prompt.format({
+    input: userInput,
+    history: historyText,
+    format_instructions: parser.getFormatInstructions(),
+  })
+
+  const rawResponse = await llm.invoke(messages)
+  return parser.parse(rawResponse)
+}
+
+function validateCircuitDesign(input: unknown): CircuitDesignResponse {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('El modelo debe devolver un objeto JSON válido.')
+  }
+
+  const data = input as Record<string, unknown>
+  if (typeof data.response !== 'string') {
+    throw new Error('El campo "response" debe ser una cadena de texto.')
+  }
+
+  const circuit = data.circuit
+  if (typeof circuit !== 'object' || circuit === null) {
+    throw new Error('El campo "circuit" debe ser un objeto.')
+  }
+
+  const parsedCircuit = validateCircuit(circuit)
+
+  return {
+    response: data.response,
+    circuit: parsedCircuit,
+  }
+}
+
+function validateCircuit(input: unknown): CircuitPlan {
+  if (typeof input !== 'object' || input === null) {
+    return {
+      title: 'Esquema propuesto',
+      summary: 'Sin resumen disponible.',
+      components: [],
+      connections: [],
+      notes: [],
+      assumptions: [],
+      warnings: [],
+    }
+  }
+
+  const circuitData = input as Record<string, unknown>
+
+  const title = typeof circuitData.title === 'string' ? circuitData.title : 'Esquema propuesto'
+  const summary = typeof circuitData.summary === 'string' ? circuitData.summary : 'Sin resumen disponible.'
+
+  const components = Array.isArray(circuitData.components)
+    ? circuitData.components
+        .map((component: unknown) => validateComponent(component))
+        .filter(
+          (component: ReturnType<typeof validateComponent>): component is NonNullable<ReturnType<typeof validateComponent>> =>
+            component !== null,
+        )
+    : []
+
+  const connections = Array.isArray(circuitData.connections)
+    ? circuitData.connections
+        .map((connection: unknown) => validateConnection(connection, components))
+        .filter(
+          (connection: ReturnType<typeof validateConnection>): connection is NonNullable<ReturnType<typeof validateConnection>> =>
+            connection !== null,
+        )
+    : []
+
+  return {
+    title,
+    summary,
+    components,
+    connections,
+    notes: Array.isArray(circuitData.notes)
+      ? circuitData.notes.filter((value: unknown): value is string => typeof value === 'string')
+      : [],
+    assumptions: Array.isArray(circuitData.assumptions)
+      ? circuitData.assumptions.filter((value: unknown): value is string => typeof value === 'string')
+      : [],
+    warnings: Array.isArray(circuitData.warnings)
+      ? circuitData.warnings.filter((value: unknown): value is string => typeof value === 'string')
+      : [],
+  }
+}
+
+function validateComponent(input: unknown): CircuitPlan['components'][number] | null {
+  if (typeof input !== 'object' || input === null) {
+    return null
+  }
+
+  const component = input as Record<string, unknown>
+
+  if (typeof component.id !== 'string' || typeof component.label !== 'string' || typeof component.type !== 'string') {
+    return null
+  }
+
+  return {
+    id: component.id,
+    label: component.label,
+    type: component.type,
+    description: typeof component.description === 'string' ? component.description : undefined,
+    pins: typeof component.pins === 'number' ? component.pins : undefined,
+    position:
+      typeof component.position === 'object' && component.position !== null
+        ? validatePosition(component.position as Record<string, unknown>)
+        : undefined,
+  }
+}
+
+function validatePosition(
+  position: Record<string, unknown>,
+): CircuitPlan['components'][number]['position'] {
+  const x = typeof position.x === 'number' ? position.x : undefined
+  const y = typeof position.y === 'number' ? position.y : undefined
+
+  if (typeof x === 'number' && typeof y === 'number') {
+    return { x, y }
+  }
+
+  return undefined
+}
+
+function validateConnection(
+  connection: unknown,
+  components: CircuitPlan['components'],
+): CircuitPlan['connections'][number] | null {
+  if (typeof connection !== 'object' || connection === null) {
+    return null
+  }
+
+  const data = connection as Record<string, unknown>
+
+  if (typeof data.from !== 'string' || typeof data.to !== 'string') {
+    return null
+  }
+
+  const componentIds = new Set(components.map((component) => component.id))
+  if (!componentIds.has(data.from) || !componentIds.has(data.to)) {
+    return null
+  }
+
+  return {
+    id: typeof data.id === 'string' ? data.id : undefined,
+    from: data.from,
+    to: data.to,
+    label: typeof data.label === 'string' ? data.label : undefined,
+    description: typeof data.description === 'string' ? data.description : undefined,
+  }
+}

--- a/scr/src/lib/langchain.ts
+++ b/scr/src/lib/langchain.ts
@@ -1,0 +1,217 @@
+import type { ChatRole } from '../types/chat'
+
+export interface PromptMessage {
+  role: ChatRole
+  content: string
+}
+
+type TemplateInput = Array<[ChatRole, string]>
+
+function interpolate(template: string, variables: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
+    if (key in variables) {
+      return variables[key]
+    }
+
+    return `{${key}}`
+  })
+}
+
+export class ChatPromptTemplate {
+  private readonly templates: TemplateInput
+
+  private constructor(templates: TemplateInput) {
+    this.templates = templates
+  }
+
+  static fromMessages(messages: TemplateInput) {
+    return new ChatPromptTemplate(messages)
+  }
+
+  format(variables: Record<string, string>): PromptMessage[] {
+    return this.templates.map(([role, template]) => ({
+      role,
+      content: interpolate(template, variables),
+    }))
+  }
+}
+
+interface StructuredParserSpec<T> {
+  instructions: string
+  validate: (input: unknown) => T
+}
+
+export class StructuredOutputParser<T> {
+  private readonly spec: StructuredParserSpec<T>
+
+  constructor(spec: StructuredParserSpec<T>) {
+    this.spec = spec
+  }
+
+  static fromSpec<T>(spec: StructuredParserSpec<T>) {
+    return new StructuredOutputParser(spec)
+  }
+
+  getFormatInstructions(): string {
+    return this.spec.instructions
+  }
+
+  parse(text: string): T {
+    try {
+      const data = JSON.parse(text)
+      return this.spec.validate(data)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`No se pudo interpretar la respuesta del modelo: ${error.message}`)
+      }
+
+      throw new Error('No se pudo interpretar la respuesta del modelo.')
+    }
+  }
+}
+
+interface OpenAIMessage {
+  role: ChatRole
+  content: Array<{ type: 'text'; text: string }>
+}
+
+interface ChatOpenAIOptions {
+  apiKey: string
+  model: string
+  temperature?: number
+  maxRetries?: number
+}
+
+interface OpenAIResponseContent {
+  type: string
+  text?: string
+  [key: string]: unknown
+}
+
+interface OpenAIResponseChoice {
+  message?: {
+    content?: OpenAIResponseContent[]
+  }
+  content?: OpenAIResponseContent[]
+  text?: string
+}
+
+interface OpenAIResponseBody {
+  output_text?: string
+  output?: OpenAIResponseChoice[]
+  choices?: OpenAIResponseChoice[]
+  error?: {
+    message?: string
+  }
+}
+
+export class ChatOpenAI {
+  private readonly apiKey: string
+  private readonly model: string
+  private readonly temperature: number
+  private readonly maxRetries: number
+
+  constructor(options: ChatOpenAIOptions) {
+    this.apiKey = options.apiKey
+    this.model = options.model
+    this.temperature = options.temperature ?? 0.2
+    this.maxRetries = options.maxRetries ?? 2
+  }
+
+  async invoke(messages: PromptMessage[]): Promise<string> {
+    const payload = {
+      model: this.model,
+      temperature: this.temperature,
+      input: messages.map<OpenAIMessage>((message) => ({
+        role: message.role,
+        content: [{ type: 'text', text: message.content }],
+      })),
+    }
+
+    let attempt = 0
+    let lastError: unknown
+
+    while (attempt <= this.maxRetries) {
+      try {
+        const response = await fetch('https://api.openai.com/v1/responses', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body: JSON.stringify(payload),
+        })
+
+        const data: OpenAIResponseBody = await response.json()
+
+        if (!response.ok) {
+          const errorMessage = data?.error?.message ?? 'Respuesta no válida del modelo.'
+          throw new Error(errorMessage)
+        }
+
+        if (typeof data.output_text === 'string') {
+          return data.output_text.trim()
+        }
+
+        const text = extractTextFromResponse(data)
+        if (text) {
+          return text
+        }
+
+        throw new Error('La respuesta del modelo no contenía texto interpretable.')
+      } catch (error) {
+        lastError = error
+        attempt += 1
+        if (attempt > this.maxRetries) {
+          if (error instanceof Error) {
+            throw error
+          }
+
+          throw new Error('No fue posible obtener una respuesta del modelo.')
+        }
+      }
+    }
+
+    if (lastError instanceof Error) {
+      throw lastError
+    }
+
+    throw new Error('No fue posible obtener una respuesta del modelo.')
+  }
+}
+
+function extractTextFromResponse(data: OpenAIResponseBody): string | null {
+  if (!data) {
+    return null
+  }
+
+  const output = Array.isArray(data.output) ? data.output : data.choices
+  if (!Array.isArray(output)) {
+    return null
+  }
+
+  for (const item of output) {
+    if (item?.message?.content) {
+      const segments = item.message.content
+      if (Array.isArray(segments)) {
+        const textSegment = segments.find((segment) => segment?.type === 'text')
+        if (textSegment && typeof textSegment.text === 'string') {
+          return textSegment.text.trim()
+        }
+      }
+    }
+
+    if (Array.isArray(item?.content)) {
+      const textSegment = item.content.find((segment) => segment?.type === 'text')
+      if (textSegment && typeof textSegment.text === 'string') {
+        return textSegment.text.trim()
+      }
+    }
+
+    if (typeof item?.text === 'string') {
+      return item.text.trim()
+    }
+  }
+
+  return null
+}

--- a/scr/src/types/chat.ts
+++ b/scr/src/types/chat.ts
@@ -1,0 +1,8 @@
+export type ChatRole = 'user' | 'assistant' | 'system'
+
+export interface ChatMessage {
+  id: string
+  role: ChatRole
+  content: string
+  createdAt: number
+}

--- a/scr/src/types/circuit.ts
+++ b/scr/src/types/circuit.ts
@@ -1,0 +1,34 @@
+export interface CircuitComponent {
+  id: string
+  label: string
+  type: string
+  description?: string
+  pins?: number
+  position?: {
+    x: number
+    y: number
+  }
+}
+
+export interface CircuitConnection {
+  id?: string
+  from: string
+  to: string
+  label?: string
+  description?: string
+}
+
+export interface CircuitPlan {
+  title: string
+  summary: string
+  components: CircuitComponent[]
+  connections: CircuitConnection[]
+  notes: string[]
+  assumptions: string[]
+  warnings: string[]
+}
+
+export interface CircuitDesignResponse {
+  response: string
+  circuit: CircuitPlan
+}


### PR DESCRIPTION
## Summary
- replace the starter Vite counter with a dual panel layout for chatting with an LLM and previewing circuit schematics
- add LangChain-style prompt, OpenAI client, and JSON validation helpers to turn free-form requests into structured circuit plans
- render circuit plans with message, component, connection, and warning details and refresh the project documentation and styles

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d331d1d4ec8322b9951bbed6e0f9bd