### PR TITLE
Polish schematic canvas with iconography and resource guidance

### DIFF
--- a/scr/src/App.css
+++ b/scr/src/App.css
@@ -319,52 +319,114 @@
 }
 
 .schematic-canvas {
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  border-radius: 18px;
-  padding: 1rem;
+  position: relative;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.2), rgba(15, 23, 42, 0.7) 65%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  padding: 1.5rem;
   overflow: hidden;
+}
+
+.schematic-canvas::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 80% 10%, rgba(94, 234, 212, 0.08), transparent 55%);
 }
 
 .schematic-canvas svg {
   width: 100%;
   height: auto;
+  color: #cbd5f5;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.schematic-canvas__grid {
+  opacity: 0.7;
+}
+
+.schematic-node {
+  transition: transform 200ms ease, filter 200ms ease;
 }
 
 .schematic-node rect {
-  fill: rgba(59, 130, 246, 0.25);
-  stroke: rgba(96, 165, 250, 0.6);
+  fill: rgba(30, 64, 175, 0.35);
+  stroke: rgba(96, 165, 250, 0.65);
+  stroke-width: 1.6;
+}
+
+.schematic-node:hover {
+  transform: translateY(-4px);
+}
+
+.schematic-node:hover rect {
+  stroke: rgba(129, 140, 248, 0.95);
+}
+
+.schematic-node__icon circle {
+  fill: rgba(30, 64, 175, 0.9);
+  stroke: rgba(165, 180, 252, 0.6);
   stroke-width: 1.5;
+}
+
+.schematic-node__icon-shape {
+  fill: none;
+  stroke: rgba(226, 232, 240, 0.95);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .schematic-node__label {
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   text-anchor: middle;
   fill: #f8fafc;
+  letter-spacing: 0.01em;
 }
 
 .schematic-node__type {
   font-size: 0.78rem;
   text-anchor: middle;
-  fill: #bfdbfe;
+  fill: rgba(191, 219, 254, 0.9);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.schematic-connection__line {
-  stroke: rgba(148, 163, 184, 0.65);
-  stroke-width: 2.2;
+.schematic-connection__path {
+  fill: none;
+  stroke: rgba(148, 197, 255, 0.75);
+  stroke-width: 2.6;
+  stroke-linecap: round;
+}
+
+.schematic-connection__endpoint {
+  fill: #1d4ed8;
+  stroke: rgba(191, 219, 254, 0.9);
+  stroke-width: 1.4;
+}
+
+.schematic-connection__label,
+.schematic-connection__description {
+  text-anchor: middle;
+  paint-order: stroke fill;
+  stroke: rgba(7, 11, 23, 0.85);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+  letter-spacing: 0.04em;
+  dominant-baseline: middle;
 }
 
 .schematic-connection__label {
   font-size: 0.72rem;
-  fill: #fde68a;
-  text-anchor: middle;
+  font-weight: 600;
+  fill: #facc15;
 }
 
 .schematic-connection__description {
   font-size: 0.68rem;
-  fill: #f1f5f9;
-  text-anchor: middle;
+  fill: #e2e8f0;
 }
 
 .schematic-details__section {
@@ -389,6 +451,29 @@
   border-color: rgba(248, 113, 113, 0.5);
   background: rgba(185, 28, 28, 0.28);
   color: #fee2e2;
+}
+
+.schematic-details__section--info {
+  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(30, 64, 175, 0.35);
+  color: #cbd5f5;
+}
+
+.schematic-details__section--info p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.schematic-details__link {
+  color: #38bdf8;
+  text-decoration: none;
+  border-bottom: 1px dashed rgba(56, 189, 248, 0.6);
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.schematic-details__link:hover {
+  color: #bae6fd;
+  border-bottom-color: rgba(186, 230, 253, 0.9);
 }
 
 .schematic-list {

--- a/scr/src/App.tsx
+++ b/scr/src/App.tsx
@@ -10,21 +10,160 @@ import type { ChatMessage } from './types/chat'
 import type { CircuitPlan } from './types/circuit'
 import './App.css'
 
+const EXAMPLE_CIRCUIT_PLAN: CircuitPlan = {
+  title: 'Circuito de ejemplo: LED con transistor y pulsador',
+  summary:
+    'Al presionar el pulsador SW1 se aplica 5 V a través de R2 a la base del transistor Q1. El transistor conduce y permite que la corriente fluya desde la fuente de 5 V por R1 y el LED, encendiéndolo. R3 mantiene la base descargada cuando el pulsador está abierto.',
+  components: [
+    {
+      id: 'vcc',
+      label: 'Fuente 5 V',
+      type: 'Fuente DC',
+      description: 'Alimentación principal del circuito para el LED y el transistor.',
+    },
+    {
+      id: 'r_led',
+      label: 'R1 220 Ω',
+      type: 'Resistencia limitadora',
+      description: 'Limita la corriente que atraviesa el LED a unos 15 mA.',
+    },
+    {
+      id: 'led',
+      label: 'D1 LED rojo',
+      type: 'LED',
+      description: 'Indicador luminoso controlado por el transistor Q1.',
+    },
+    {
+      id: 'q1',
+      label: 'Q1 2N2222',
+      type: 'Transistor NPN',
+      description: 'Actúa como interruptor para energizar al LED cuando recibe corriente de base.',
+    },
+    {
+      id: 'r_base',
+      label: 'R2 4.7 kΩ',
+      type: 'Resistencia de base',
+      description: 'Limita la corriente de base del transistor a aproximadamente 1 mA.',
+    },
+    {
+      id: 'sw1',
+      label: 'SW1 Pulsador',
+      type: 'Interruptor momentáneo',
+      description: 'Aplica 5 V a la red de polarización cuando se presiona.',
+    },
+    {
+      id: 'r_pull',
+      label: 'R3 100 kΩ',
+      type: 'Resistencia de pull-down',
+      description: 'Mantiene la base del transistor a potencial de tierra cuando el pulsador está abierto.',
+    },
+    {
+      id: 'gnd',
+      label: 'GND',
+      type: 'Referencia',
+      description: 'Retorno común del circuito.',
+    },
+  ],
+  connections: [
+    {
+      id: 'vcc-rled',
+      from: 'vcc',
+      to: 'r_led',
+      label: '5 V',
+      description: 'Alimentación hacia el LED a través de la resistencia limitadora.',
+    },
+    {
+      id: 'rled-led',
+      from: 'r_led',
+      to: 'led',
+      label: '≈15 mA',
+      description: 'Corriente limitada que atraviesa el LED.',
+    },
+    {
+      id: 'led-q1',
+      from: 'led',
+      to: 'q1',
+      description: 'El cátodo del LED se conecta al colector del transistor.',
+    },
+    {
+      id: 'q1-gnd',
+      from: 'q1',
+      to: 'gnd',
+      label: 'Emisor a tierra',
+      description: 'El transistor conmuta el retorno del LED hacia tierra.',
+    },
+    {
+      id: 'vcc-sw1',
+      from: 'vcc',
+      to: 'sw1',
+      description: 'Proporciona 5 V al pulsador.',
+    },
+    {
+      id: 'sw1-rbase',
+      from: 'sw1',
+      to: 'r_base',
+      description: 'Al cerrar SW1, la corriente fluye hacia la resistencia de base.',
+    },
+    {
+      id: 'rbase-q1',
+      from: 'r_base',
+      to: 'q1',
+      label: 'Base Q1',
+      description: 'La resistencia limita la corriente que entra a la base.',
+    },
+    {
+      id: 'rpull-q1',
+      from: 'r_pull',
+      to: 'q1',
+      description: 'R3 mantiene la base referenciada a tierra.',
+    },
+    {
+      id: 'rpull-gnd',
+      from: 'r_pull',
+      to: 'gnd',
+      label: 'Pull-down',
+    },
+  ],
+  notes: [
+    'Puedes sustituir el transistor 2N2222 por cualquier NPN de propósito general (ej. BC547) ajustando los valores de resistencia.',
+    'Si utilizas una fuente distinta a 5 V, recalcula el valor de R1 para mantener la corriente del LED dentro de especificación.',
+  ],
+  assumptions: [
+    'Se asume una fuente regulada de 5 V y un LED rojo con caída aproximada de 2 V.',
+    'El transistor está conectado en configuración de conmutación saturada.',
+  ],
+  warnings: [
+    'Verifica la polaridad del LED y las conexiones del transistor antes de energizar el circuito.',
+  ],
+}
+
+const INITIAL_EXAMPLE_MESSAGE =
+  'Mientras tanto, te muestro un circuito de ejemplo con una fuente de 5 V, un LED y un transistor con pulsador para que veas el formato de salida.'
+
 const INITIAL_ASSISTANT_MESSAGE = `Hola, soy Schematicia. Describe el circuito que necesitas y te ayudaré a proponer un esquema,
 lista de componentes y recomendaciones para construirlo de forma segura.`
 
 function App() {
-  const [messages, setMessages] = useState<ChatMessage[]>([
-    {
-      id: 'welcome',
-      role: 'assistant',
-      content: INITIAL_ASSISTANT_MESSAGE,
-      createdAt: Date.now(),
-    },
-  ])
+  const [messages, setMessages] = useState<ChatMessage[]>(() => {
+    const now = Date.now()
+    return [
+      {
+        id: 'welcome',
+        role: 'assistant',
+        content: INITIAL_ASSISTANT_MESSAGE,
+        createdAt: now,
+      },
+      {
+        id: 'example',
+        role: 'assistant',
+        content: `${INITIAL_EXAMPLE_MESSAGE}\n\n${EXAMPLE_CIRCUIT_PLAN.summary}`,
+        createdAt: now + 1,
+      },
+    ]
+  })
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [currentPlan, setCurrentPlan] = useState<CircuitPlan | null>(null)
+  const [currentPlan, setCurrentPlan] = useState<CircuitPlan | null>(EXAMPLE_CIRCUIT_PLAN)
 
   const [apiKey, setApiKey] = useLocalStorage('schematicia_openai_api_key', '')
   const [model, setModel] = useLocalStorage('schematicia_openai_model', 'gpt-4o-mini')

--- a/scr/src/components/SchematicCanvas.tsx
+++ b/scr/src/components/SchematicCanvas.tsx
@@ -1,11 +1,110 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactElement } from 'react'
 
 import type { CircuitPlan } from '../types/circuit'
 
-const NODE_WIDTH = 160
-const NODE_HEIGHT = 64
-const HORIZONTAL_PADDING = 120
-const VERTICAL_SPACING = 120
+const NODE_WIDTH = 200
+const NODE_HEIGHT = 120
+const TOP_PADDING = 160
+const SIDE_PADDING = 140
+const COLUMN_GAP = 140
+const ROW_GAP = 150
+const ICON_DIAMETER = 38
+
+type IconKey =
+  | 'supply'
+  | 'led'
+  | 'transistor'
+  | 'switch'
+  | 'resistor'
+  | 'ground'
+  | 'generic'
+
+function resolveIconKey(type: string): IconKey {
+  const normalized = type.toLowerCase()
+
+  if (normalized.includes('fuente') || normalized.includes('vcc') || normalized.includes('dc')) {
+    return 'supply'
+  }
+
+  if (normalized.includes('led')) {
+    return 'led'
+  }
+
+  if (normalized.includes('transistor') || normalized.includes('mosfet')) {
+    return 'transistor'
+  }
+
+  if (normalized.includes('interruptor') || normalized.includes('pulsador') || normalized.includes('switch')) {
+    return 'switch'
+  }
+
+  if (normalized.includes('resist')) {
+    return 'resistor'
+  }
+
+  if (normalized.includes('gnd') || normalized.includes('tierra') || normalized.includes('ground')) {
+    return 'ground'
+  }
+
+  return 'generic'
+}
+
+const ICONS: Record<IconKey, ReactElement> = {
+  supply: (
+    <g className="schematic-node__icon-shape">
+      <circle cx="0" cy="0" r="9" />
+      <line x1="-12" y1="-12" x2="12" y2="-12" />
+      <line x1="-12" y1="12" x2="12" y2="12" />
+      <line x1="0" y1="-16" x2="0" y2="16" />
+    </g>
+  ),
+  led: (
+    <g className="schematic-node__icon-shape">
+      <polygon points="-4,-6 6,0 -4,6" />
+      <line x1="-12" y1="0" x2="-4" y2="0" />
+      <line x1="6" y1="0" x2="14" y2="0" />
+      <path d="M 2 -10 L 10 -18" />
+      <path d="M 6 -8 L 14 -16" />
+    </g>
+  ),
+  transistor: (
+    <g className="schematic-node__icon-shape">
+      <circle cx="-2" cy="0" r="10" />
+      <line x1="-12" y1="-10" x2="6" y2="8" />
+      <line x1="-12" y1="10" x2="8" y2="-12" />
+      <polyline points="2,12 12,12 12,-2" />
+      <polygon points="8,-2 12,-2 12,2" />
+    </g>
+  ),
+  switch: (
+    <g className="schematic-node__icon-shape">
+      <line x1="-14" y1="8" x2="-2" y2="8" />
+      <line x1="10" y1="-8" x2="14" y2="-8" />
+      <circle cx="-2" cy="8" r="3" />
+      <circle cx="10" cy="-8" r="3" />
+      <line x1="-2" y1="8" x2="10" y2="-8" />
+    </g>
+  ),
+  resistor: (
+    <g className="schematic-node__icon-shape">
+      <polyline points="-14,0 -10,-6 -6,6 -2,-6 2,6 6,-6 10,6 14,0" />
+    </g>
+  ),
+  ground: (
+    <g className="schematic-node__icon-shape">
+      <line x1="-12" y1="8" x2="12" y2="8" />
+      <line x1="-8" y1="12" x2="8" y2="12" />
+      <line x1="-4" y1="16" x2="4" y2="16" />
+      <line x1="0" y1="-6" x2="0" y2="8" />
+    </g>
+  ),
+  generic: (
+    <g className="schematic-node__icon-shape">
+      <rect x="-10" y="-10" width="20" height="20" rx="4" />
+      <circle cx="0" cy="0" r="3" />
+    </g>
+  ),
+}
 
 interface SchematicCanvasProps {
   plan: CircuitPlan
@@ -14,22 +113,51 @@ interface SchematicCanvasProps {
 export function SchematicCanvas({ plan }: SchematicCanvasProps) {
   const layout = useMemo(() => {
     const positions = new Map<string, { x: number; y: number }>()
+    const components = plan.components
+    const columns = components.length > 6 ? 4 : components.length > 4 ? 3 : 2
+    const columnWidth = NODE_WIDTH + COLUMN_GAP
 
-    plan.components.forEach((component, index) => {
+    components.forEach((component, index) => {
       if (component.position) {
         positions.set(component.id, component.position)
         return
       }
 
-      const column = index % 2
-      const row = Math.floor(index / 2)
-      const x = HORIZONTAL_PADDING + column * (NODE_WIDTH + 120)
-      const y = 120 + row * VERTICAL_SPACING
+      const column = index % columns
+      const row = Math.floor(index / columns)
+      const x = SIDE_PADDING + column * columnWidth + NODE_WIDTH / 2
+      const y = TOP_PADDING + row * ROW_GAP
       positions.set(component.id, { x, y })
     })
 
-    const width = plan.components.length > 1 ? HORIZONTAL_PADDING * 2 + NODE_WIDTH * 2 + 120 : 520
-    const height = Math.max(440, 200 + Math.ceil(plan.components.length / 2) * VERTICAL_SPACING)
+    if (components.length === 1) {
+      const [first] = components
+      if (first && !first.position) {
+        positions.set(first.id, { x: SIDE_PADDING + NODE_WIDTH / 2, y: TOP_PADDING })
+      }
+    }
+
+    let minX = Number.POSITIVE_INFINITY
+    let maxX = Number.NEGATIVE_INFINITY
+    let minY = Number.POSITIVE_INFINITY
+    let maxY = Number.NEGATIVE_INFINITY
+
+    positions.forEach(({ x, y }) => {
+      minX = Math.min(minX, x)
+      maxX = Math.max(maxX, x)
+      minY = Math.min(minY, y)
+      maxY = Math.max(maxY, y)
+    })
+
+    if (!Number.isFinite(minX)) {
+      minX = 0
+      maxX = NODE_WIDTH
+      minY = 0
+      maxY = NODE_HEIGHT
+    }
+
+    const width = Math.max(640, maxX - minX + SIDE_PADDING * 2)
+    const height = Math.max(480, maxY - minY + TOP_PADDING)
 
     return { positions, width, height }
   }, [plan.components])
@@ -38,10 +166,25 @@ export function SchematicCanvas({ plan }: SchematicCanvasProps) {
     <div className="schematic-canvas">
       <svg viewBox={`0 0 ${layout.width} ${layout.height}`} role="img" aria-label="Esquema del circuito propuesto">
         <defs>
-          <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          <pattern id="schematic-grid" width="32" height="32" patternUnits="userSpaceOnUse">
+            <path d="M 32 0 L 0 0 0 32" fill="none" stroke="rgba(148, 163, 184, 0.12)" strokeWidth="1" />
+          </pattern>
+          <marker id="schematic-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(148, 197, 255, 0.85)" />
           </marker>
+          <filter id="node-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="10" stdDeviation="8" floodColor="rgba(59, 130, 246, 0.25)" />
+          </filter>
         </defs>
+
+        <rect
+          className="schematic-canvas__grid"
+          x="0"
+          y="0"
+          width={layout.width}
+          height={layout.height}
+          fill="url(#schematic-grid)"
+        />
 
         {plan.connections.map((connection, index) => {
           const from = layout.positions.get(connection.from)
@@ -50,20 +193,27 @@ export function SchematicCanvas({ plan }: SchematicCanvasProps) {
             return null
           }
 
-          const midX = (from.x + to.x) / 2
-          const midY = (from.y + to.y) / 2
           const lineId = connection.id ?? `${connection.from}-${connection.to}-${index}`
+          const dx = to.x - from.x
+          const dy = to.y - from.y
+          const offset = Math.min(180, Math.max(60, Math.hypot(dx, dy) * 0.35))
+          const curvature = dy === 0 ? offset * Math.sign(dx || 1) : offset * Math.sign(dy)
+          const controlX = from.x + dx / 2
+          const controlY = from.y + dy / 2 - curvature
+          const midX = (from.x + to.x) / 2
+          const midY = (from.y + to.y) / 2 - curvature * 0.25
 
           return (
             <g key={lineId} className="schematic-connection">
-              <line
-                x1={from.x}
-                y1={from.y}
-                x2={to.x}
-                y2={to.y}
-                markerEnd="url(#arrow)"
-                className="schematic-connection__line"
-              />
+              <path
+                className="schematic-connection__path"
+                d={`M ${from.x} ${from.y} Q ${controlX} ${controlY} ${to.x} ${to.y}`}
+                markerEnd="url(#schematic-arrow)"
+              >
+                <title>{connection.description ?? connection.label ?? `${connection.from} → ${connection.to}`}</title>
+              </path>
+              <circle className="schematic-connection__endpoint" cx={from.x} cy={from.y} r={5} />
+              <circle className="schematic-connection__endpoint" cx={to.x} cy={to.y} r={5} />
               {connection.label ? (
                 <text x={midX} y={midY - 6} className="schematic-connection__label">
                   {connection.label}
@@ -84,13 +234,29 @@ export function SchematicCanvas({ plan }: SchematicCanvasProps) {
             return null
           }
 
+          const iconKey = resolveIconKey(component.type)
+
           return (
-            <g key={component.id} className="schematic-node" transform={`translate(${position.x - NODE_WIDTH / 2}, ${position.y - NODE_HEIGHT / 2})`}>
-              <rect rx={12} ry={12} width={NODE_WIDTH} height={NODE_HEIGHT} />
-              <text x={NODE_WIDTH / 2} y={26} className="schematic-node__label">
+            <g
+              key={component.id}
+              className="schematic-node"
+              transform={`translate(${position.x - NODE_WIDTH / 2}, ${position.y - NODE_HEIGHT / 2})`}
+              filter="url(#node-shadow)"
+            >
+              <title>{component.description ?? component.type}</title>
+              <rect rx={18} ry={18} width={NODE_WIDTH} height={NODE_HEIGHT} />
+              <g
+                className="schematic-node__icon"
+                transform={`translate(${NODE_WIDTH / 2}, ${ICON_DIAMETER})`}
+                aria-hidden="true"
+              >
+                <circle r={ICON_DIAMETER / 2} />
+                <g transform="translate(0, 2)">{ICONS[iconKey]}</g>
+              </g>
+              <text x={NODE_WIDTH / 2} y={ICON_DIAMETER + 44} className="schematic-node__label">
                 {component.label}
               </text>
-              <text x={NODE_WIDTH / 2} y={48} className="schematic-node__type">
+              <text x={NODE_WIDTH / 2} y={ICON_DIAMETER + 66} className="schematic-node__type">
                 {component.type}
               </text>
             </g>

--- a/scr/src/components/SchematicDetails.tsx
+++ b/scr/src/components/SchematicDetails.tsx
@@ -99,6 +99,23 @@ export function SchematicDetails({ plan }: SchematicDetailsProps) {
         </section>
       ) : null}
 
+      <section className="schematic-details__section schematic-details__section--info">
+        <h3>Recursos visuales</h3>
+        <p>
+          Para enriquecer la iconografía de tus diagramas puedes apoyarte en colecciones públicas como{' '}
+          <a
+            className="schematic-details__link"
+            href="https://tabler-icons.io/i/circuit-resistor"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Tabler Icons (paquete Circuit)
+          </a>
+          , que ofrece símbolos vectoriales de electrónica bajo licencia MIT, listos para incorporar en documentación o
+          presentaciones.
+        </p>
+      </section>
+
       <section className="schematic-details__section">
         <h3>JSON sugerido</h3>
         <pre className="schematic-details__json">{JSON.stringify(plan, null, 2)}</pre>


### PR DESCRIPTION
## Summary
- redesign the schematic canvas with a subtle grid, curved connections, endpoint markers, and drop-shadowed nodes that include contextual electronics icons
- refresh the canvas styling to support the new visuals and hover states while improving label legibility
- highlight a public MIT-licensed electronics icon set in the details panel for users who need additional symbols

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3445e08b88322934dd1c90e53bd41